### PR TITLE
Simple Dockerfile for LPP deployment

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,33 @@
+FROM fedora:43
+LABEL authors="jeandet"
+
+ARG PORT=6570
+
+ENV STORAGE_PATH=/storage \
+    DB_PATH=/db \
+    LOG_PATH=/log \
+    PORT=$PORT
+
+RUN useradd cocat && mkdir -p $STORAGE_PATH $DB_PATH  $LOG_PATH/cocat \
+    && chown -R cocat $STORAGE_PATH $DB_PATH  $LOG_PATH \
+    && dnf install -y git python3 \
+    && dnf clean all
+
+USER cocat
+WORKDIR /home/cocat
+
+
+
+RUN python3 -m ensurepip \
+    && python3 -mpip install -U pip \
+    && python3 -mpip install -U cocat["server"]
+
+ADD entry_point.sh /home/cocat/entry_point.sh
+ADD create-user.sh /usr/local/bin/create-user
+
+VOLUME $STORAGE_PATH
+VOLUME $LOG_PATH
+VOLUME $DB_PATH
+EXPOSE $PORT/tcp
+
+ENTRYPOINT ["/home/cocat/entry_point.sh"]

--- a/docker/build_and_push.sh
+++ b/docker/build_and_push.sh
@@ -1,0 +1,2 @@
+docker build -t  129.104.6.172:32219/sciqlop/cocat-server .
+docker push 129.104.6.172:32219/sciqlop/cocat-server

--- a/docker/create-user.sh
+++ b/docker/create-user.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+
+set -e
+~/.local/bin/cocat create-user --email "$1" --password "$2" --db-path "$DB_PATH/users.db"

--- a/docker/entry_point.sh
+++ b/docker/entry_point.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+
+set -e
+
+echo  "Starting cocat server..."
+~/.local/bin/cocat serve --host "0.0.0.0" --port "$PORT" --update_dir "$STORAGE_PATH" --db-path "$DB_PATH/users.db"
+echo "Cocat server stopped."


### PR DESCRIPTION
This pull request introduces a new Docker setup for the cocat server, including a Dockerfile, entry point scripts, and build automation. The main focus is on containerizing the application for easier deployment and management.

**Docker containerization and environment setup:**

* Added a new `Dockerfile` that sets up a Fedora 43-based container, configures environment variables, installs dependencies (`git`, `python3`, and `cocat[server]`), creates necessary directories, sets up volumes, exposes the server port, and specifies the entry point script.

**Automation scripts:**

* Added `entry_point.sh` to start the cocat server with specified host, port, storage, and database paths, and log output messages (for later usage).
* Added `create-user.sh` to automate user creation using the cocat CLI with email and password arguments.
* Added `build_and_push.sh` to build the Docker image and push it to a remote registry (LPP internal setup).